### PR TITLE
Add template sanitize toggle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,10 +47,6 @@ repos:
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
-  - repo: https://github.com/returntocorp/semgrep
-    rev: v1.89.0
-    hooks:
-      - id: semgrep
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: SMTP
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **content_id4** | optional | Optional content-id for attachment, typically used in image link referrals | string | |
 **attachment5** | optional | Vault id for attachment | string | |
 **content_id5** | optional | Optional content-id for attachment, typically used in image link referrals | string | |
+**should_sanitize_template** | optional | Sanitize the HTML body using the Bleach library to remove unsafe tags and attributes | |
 
 #### Action Output
 
@@ -360,6 +361,7 @@ action_result.parameter.html_body | string | | <html><h2>HTML heading</h2><body>
 action_result.parameter.subject | string | | Test |
 action_result.parameter.text_body | string | | This is text body. |
 action_result.parameter.to | string | `email` | receiver@testdomain.com |
+action_result.parameter.should_sanitize_template | boolean | | |
 action_result.data | string | | |
 action_result.summary | string | | |
 action_result.message | string | | Email sent |

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **content_id4** | optional | Optional content-id for attachment, typically used in image link referrals | string | |
 **attachment5** | optional | Vault id for attachment | string | |
 **content_id5** | optional | Optional content-id for attachment, typically used in image link referrals | string | |
-**should_sanitize_template** | optional | Sanitize the HTML body using the Bleach library to remove unsafe tags and attributes | |
+**should_sanitize_template** | optional | Sanitize the HTML body using the Bleach library to remove unsafe tags and attributes | boolean | |
 
 #### Action Output
 

--- a/README.md
+++ b/README.md
@@ -361,18 +361,18 @@ action_result.parameter.html_body | string | | <html><h2>HTML heading</h2><body>
 action_result.parameter.subject | string | | Test |
 action_result.parameter.text_body | string | | This is text body. |
 action_result.parameter.to | string | `email` | receiver@testdomain.com |
-action_result.parameter.should_sanitize_template | boolean | | |
 action_result.data | string | | |
 action_result.summary | string | | |
 action_result.message | string | | Email sent |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.should_sanitize_template | boolean | | |
 
 ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+Adding should_sanitize_template parameter to allow disabling template sanitization if the template is benign

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-Adding should_sanitize_template parameter to allow disabling template sanitization if the template is benign
+* Adding should_sanitize_template parameter to allow disabling template sanitization if the template is benign

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,6 +1,6 @@
 # File: request_handler.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smtp.json
+++ b/smtp.json
@@ -518,6 +518,12 @@
                     "description": "Optional content-id for attachment, typically used in image link referrals",
                     "data_type": "string",
                     "order": 18
+                },
+                "should_sanitize_template": {
+                    "description": "Sanitize the HTML body using the Bleach library to remove unsafe tags and attributes",
+                    "data_type": "boolean",
+                    "order": 19,
+                    "default": true
                 }
             },
             "output": [

--- a/smtp.json
+++ b/smtp.json
@@ -13,7 +13,7 @@
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
     "rest_handler": "request_handler.handle_request",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "logo": "logo_splunk.svg",
     "logo_dark": "logo_splunk_dark.svg",
     "python_version": "3.9, 3.13",
@@ -694,6 +694,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.should_sanitize_template",
+                    "data_type": "boolean"
                 }
             ],
             "versions": "EQ(*)",

--- a/smtp_connector.py
+++ b/smtp_connector.py
@@ -1078,14 +1078,16 @@ class SmtpConnector(BaseConnector):
         email_html = param["html_body"]
         email_text = param.get("text_body")
         attachment_json = param.get("attachment_json")
+        should_sanitize = param.get("should_sanitize_template", True)
 
-        email_html = bleach.clean(
-            text=email_html,
-            tags=self.SAFE_HTML_TAGS,
-            attributes=BLEACH_SAFE_HTML_ATTRIBUTES,
-            css_sanitizer=CSSSanitizer(allowed_css_properties=all_styles),
-            protocols=list(bleach.ALLOWED_PROTOCOLS) + SMTP_BLEACH_ALLOWED_PROTOCOLS,
-        )
+        if should_sanitize:
+            email_html = bleach.clean(
+                text=email_html,
+                tags=self.SAFE_HTML_TAGS,
+                attributes=BLEACH_SAFE_HTML_ATTRIBUTES,
+                css_sanitizer=CSSSanitizer(allowed_css_properties=all_styles),
+                protocols=list(bleach.ALLOWED_PROTOCOLS) + SMTP_BLEACH_ALLOWED_PROTOCOLS,
+            )
         email_html = unescape(email_html)
 
         encoding = config.get(SMTP_ENCODING, False)

--- a/smtp_connector.py
+++ b/smtp_connector.py
@@ -1,6 +1,6 @@
 # File: smtp_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smtp_consts.py
+++ b/smtp_consts.py
@@ -1,6 +1,6 @@
 # File: smtp_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Features
Adding a should_sanitize_template parameter to allow disabling template sanitization if the template is benign

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md? No
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [X] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
